### PR TITLE
Improvements to setup script for Linux compatibility

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euo pipefail
 
 # This script is used to setup the project, install erlang, elixir, and mix dependencies.
 # NOTE: it currently assumes you are using MacOS.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 # This script is used to setup the project, install erlang, elixir, and mix dependencies.
@@ -15,12 +15,27 @@ function install_asdf_deps() {
 	# Linux
 	Linux*)
 		echo "Setting up project for Linux"
-		sudo apt install curl git -y
-		# TODO: what if they don't use apt or don't have sudo?
+
+		# Currently supporting APT & DNF only.
+		for candidate in apt-get dnf
+		do
+			if [ -x "$(command -v ${candidate})" ]
+			then
+				package_manager=$candidate
+			fi
+		done
+
+		if [ -z "${package_manager+X}" ]
+		then
+			>&2 echo "Unknown package manager."
+			exit +1
+		fi
+
+		sudo "${package_manager}" install -y curl git automake autoconf libncurses-dev
 		;;
 	*)
-		echo "Unsupported OS: $(uname -s)"
-		exit 1
+		>&2 echo "Unsupported OS: $(uname -s)"
+		exit +2
 		;;
 	esac
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # This script is used to setup the project, install erlang, elixir, and mix dependencies.
-# NOTE: it currently assumes you are using MacOS.
+# NOTE: it currently assumes you are using MacOS or a Linux distribution derived from Debian or RedHat
 
 # Install dependencies for asdf (curl, git, etc.)
 function install_asdf_deps() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,23 +41,38 @@ function install_asdf_deps() {
 }
 
 function install_asdf() {
-	git clone https://github.com/asdf-vm/asdf.git ~/.asdf
+	ASDF_DIR="$HOME/.asdf"
 
-	# Add asdf to your shell
+	# Avoid reinstalling if ASDF directory exists.
+	if [ -d "$ASDF_DIR" ]
+	then
+		echo "Existing ASDF directory found, skipping installation..."
+		return
+	fi
+
+	git clone https://github.com/asdf-vm/asdf.git "$ASDF_DIR"
+
+	ASDF_ENV="$ASDF_DIR/asdf.sh"
+
+	# Add asdf to your shell and source RC file to include ASDF path additions.
 	case $SHELL in
 		*/bash)
-			echo -e "\n. $HOME/.asdf/asdf.sh" >> ~/.bashrc
+			echo -e "\nsource $ASDF_ENV" >> ~/.bashrc
+			source "$ASDF_ENV"
 			;;
 		*/zsh)
-			echo -e "\n. $HOME/.asdf/asdf.sh" >> ~/.zshrc
+			echo -e "\nsource $ASDF_ENV" >> ~/.zshrc
+			source "$ASDF_ENV"
 			;;
 		*/fish)
 			echo -e "\nsource $HOME/.asdf/asdf.fish" >> ~/.config/fish/config.fish
+			# TODO: Reload to adjust path?
 			;;
 		*)
-			echo "Unsupported shell: $SHELL"
-			echo "Please add the following line to your shell configuration file:"
-			echo ". $HOME/.asdf/asdf.sh"
+			>&2 echo "Unsupported shell: $SHELL"
+			>&2 echo "Please add the following line to your shell configuration file:"
+			>&2 echo ". $HOME/.asdf/asdf.sh"
+			exit +3
 			;;
 	esac
 }


### PR DESCRIPTION

- Handle RedHat based distributions using dnf package manager (vs apt on Debian)
- Avoid asdf reinstallation & bashrc changes if already present
- Use strict bash mode
- Fit & polish: write error messages to stderr (vs stdout) and return distinct exit codes in case of fatal errors
- Make the script executable (git preserves mode)
 
@SachinMeier 