### PR TITLE
switch from `asdf` to `mise`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.18.4-otp-27
-erlang 27.2.4

--- a/README.md
+++ b/README.md
@@ -2,54 +2,53 @@
 
 River's Proof of Reserves implementation in Elixir. This implementation is based on BitMEX's Proof of Reserves Python implementation, found [here](https://github.com/BitMEX/proof-of-reserves-liabilities).
 
-This library is used by River to generate its Proof of Liabilities tree and to allow users to download and verify the Proof of Liabilities. 
+This library is used by River to generate its Proof of Liabilities tree and to allow users to download and verify the Proof of Liabilities.
 
 See River's [Proof of Reserves page](https://river.com/reserves) for more information.
 
-## Verifying River's Proof of Reserves 
+## Verifying River's Proof of Reserves
 
 This library comes with a `verify_liabilities.exs` script that will verify River's Proof of Reserves and the balances of any accounts you provide. The following steps will walk you through the process of verifying River's Proof of Reserves.
 
 ### 1. Fetch the Proof of Reserves Data
 
-Go to River's [Proof of Reserves](https://river.com/reserves) page. Log in with the email address you used to sign up for River. 
+Go to River's [Proof of Reserves](https://river.com/reserves) page. Log in with the email address you used to sign up for River.
 
-Click "Verify Liabilities" and select the "Verify on your computer" option. This will allow you to download the Proof of Liabilities CSV file. Note the path to this CSV file, as you will need to provide it to the command in the next step. 
+Click "Verify Liabilities" and select the "Verify on your computer" option. This will allow you to download the Proof of Liabilities CSV file. Note the path to this CSV file, as you will need to provide it to the command in the next step.
 
 Click "Continue" and you will be prompted to run the setup script also seen in the next step.
 
 ### 2. Setup the Project
 
-In your terminal, run this command to clone the repository and install the dependencies. This step will install [asdf](https://asdf-vm.com/) and the Erlang/Elixir SDK. 
+In your terminal, run this command to clone the repository and install the dependencies. This step will install [mise](https://mise.run/) and the Erlang/Elixir SDK.
 
-If you already have Erlang and Elixir installed or have already verified River's Proof of Reserves before, you can skip this step. If you have asdf installed but not Erlang/Elixir, you can install the SDK with asdf by running `asdf install` from this directory and skip this step.
+If you already have Erlang and Elixir installed or have already verified River's Proof of Reserves before, you can skip this step. If you have mise installed but not Erlang/Elixir, you can install the SDK with mise by running `mise install` from this directory and skip this step.
 
 ```bash
 git clone https://github.com/RiverFinancial/proof-of-reserves.git
 cd proof-of-reserves
 ./scripts/setup.sh
-source $HOME/.asdf/asdf.sh
 ```
 
-This script will install Erlang/Elixir and the project dependencies. It will then compile the library. 
+This script will install Erlang/Elixir and the project dependencies. It will then compile the library.
 
-Back in River's Proof of Reserves flow, click "Continue" and you will see the verification command, also shown in the step below. 
+Back in River's Proof of Reserves flow, click "Continue" and you will see the verification command, also shown in the step below.
 
 ### 2. Run the Verification Script
 
-You will need to replace a few variables in the command below to run the script successfully. These values can be found in the River Proof of Reserves flow. If you followed the steps above, you will now see the command in the final screen. The command on the River page will already have your email and account string(s) filled in. You will need to fill in the `<CSV_PATH>` with the path to the CSV file you downloaded in Step 1. 
+You will need to replace a few variables in the command below to run the script successfully. These values can be found in the River Proof of Reserves flow. If you followed the steps above, you will now see the command in the final screen. The command on the River page will already have your email and account string(s) filled in. You will need to fill in the `<CSV_PATH>` with the path to the CSV file you downloaded in Step 1.
 
 - `<EMAIL>` with the email address you used to sign up for River.
 - `<ACCOUNT_STRING>` in the format `<ACCOUNT_ID>:<ACCOUNT_KEY>`. If you have multiple accounts, you can provide this flag multiple times, like so: `--account <ACCOUNT_STRING_1> --account <ACCOUNT_STRING_2>`. You can find your account ID and key in the Proof of Reserves flow.
-- `<CSV_PATH>` with the path to the CSV file you downloaded in Step 1. The downloaded file will initially be zipped, so you will need to unzip it before providing the path to the CSV file. 
+- `<CSV_PATH>` with the path to the CSV file you downloaded in Step 1. The downloaded file will initially be zipped, so you will need to unzip it before providing the path to the CSV file.
 
 ```bash
 mix run verify_liabilities.exs --email <EMAIL> --account <ACCOUNT_STRING> --file <CSV_PATH>
 ```
 
-If the verification is successful, it will output your balance and a summary of the verification. 
+If the verification is successful, it will output your balance and a summary of the verification.
 
-If you click continue on the River page, you can check that these balances are correct. 
+If you click continue on the River page, you can check that these balances are correct.
 
 ## Installation as a Library
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+elixir = "1.18.4-otp-27"
+erlang = "27.2.4"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 # This script is used to setup the project, install erlang, elixir, and mix dependencies.
 # NOTE: it currently assumes you are using MacOS or a Linux distribution derived from Debian or RedHat
 
-# Install dependencies for asdf (curl, git, etc.)
-function install_asdf_deps() {
+# Install dependencies for mise (curl, git, etc.)
+function install_mise_deps() {
 	case $(uname -s) in
 	# MacOS
 	Darwin*)
@@ -42,49 +42,51 @@ function install_asdf_deps() {
 	esac
 }
 
-function install_asdf() {
-	echo "Installing asdf (version manager for erlang and elixir)..."
-	ASDF_DIR="$HOME/.asdf"
-
-	# Avoid reinstalling if asdf directory exists.
-	if [ -d "$ASDF_DIR" ]
-	then
-		echo "Existing asdf directory found, skipping installation..."
+function install_mise() {
+	echo "Installing mise (version manager for erlang and elixir)..."
+	
+	# Check if mise is already installed
+	if command -v mise &> /dev/null; then
+		echo "mise is already installed, skipping installation..."
 		return
 	fi
 
-	git clone https://github.com/asdf-vm/asdf.git "$ASDF_DIR"
+	# Install mise using the official installer
+	curl https://mise.run | sh
 
-	ASDF_ENV="$ASDF_DIR/asdf.sh"
+	# Add mise to PATH for the current session
+	export PATH="$HOME/.local/bin:$PATH"
 
-	# Add asdf to your shell and source RC file to include ASDF path additions.
+	# Add mise to shell configuration
 	if [ -z "${SHELL+X}" ]; then
 		SHELL=$(echo $0)
 	fi
 
 	case $SHELL in
 		*/bash)
-			echo "\nsource $ASDF_ENV" >> ~/.bashrc
-			source "$ASDF_ENV"
-
-			echo "Sourcing asdf $ASDF_ENV"
+			if ! grep -q 'eval "$(~/.local/bin/mise activate bash)"' ~/.bashrc 2>/dev/null; then
+				echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
+			fi
+			eval "$(~/.local/bin/mise activate bash)"
+			echo "Sourcing mise for bash"
 			;;
 		*/zsh)
-			echo "\nsource $ASDF_ENV" >> ~/.zshrc
-			source "$ASDF_ENV"
-
-			echo "Sourcing asdf $ASDF_ENV"
+			if ! grep -q 'eval "$(~/.local/bin/mise activate zsh)"' ~/.zshrc 2>/dev/null; then
+				echo 'eval "$(~/.local/bin/mise activate zsh)"' >> ~/.zshrc
+			fi
+			eval "$(~/.local/bin/mise activate zsh)"
+			echo "Sourcing mise for zsh"
 			;;
 		*/fish)
-			echo "\nsource $HOME/.asdf/asdf.fish" >> ~/.config/fish/config.fish
-			# TODO: Reload to adjust path?
-
-			echo "Sourcing asdf $ASDF_ENV"
+			if ! grep -q '~/.local/bin/mise activate fish' ~/.config/fish/config.fish 2>/dev/null; then
+				echo '~/.local/bin/mise activate fish | source' >> ~/.config/fish/config.fish
+			fi
+			~/.local/bin/mise activate fish | source
+			echo "Sourcing mise for fish"
 			;;
 		*)
 			>&2 echo "Unsupported shell: $SHELL"
-			>&2 echo "Please add the following line to your shell configuration file:"
-			>&2 echo ". $HOME/.asdf/asdf.sh"
+			>&2 echo "Please add mise to your PATH and run: mise activate"
 			exit +3
 			;;
 	esac
@@ -92,23 +94,21 @@ function install_asdf() {
 
 function install_erlang_elixir() {
 	echo "Installing erlang and elixir..."
-	# Install erlang & elixir using asdf.
-	# The plugins will be added to asdf and the versions will be installed according to the .tool-versions file.
-	ASDF=$(which asdf)
-	if [ -f "$HOME/.asdf/asdf.sh" ]; then
-		echo "Sourcing asdf"
-		source "$HOME/.asdf/asdf.sh"
-	fi
-
-	if [ -z "${ASDF+X}" ]; then
-		echo "asdf not found, please install asdf first"
+	# Install erlang & elixir using mise.
+	# The versions will be installed according to the mise.toml file.
+	
+	# Ensure mise is in PATH
+	export PATH="$HOME/.local/bin:$PATH"
+	
+	MISE=$(which mise || echo "$HOME/.local/bin/mise")
+	
+	if [ ! -x "$MISE" ]; then
+		echo "mise not found, please install mise first"
 		exit +4
 	fi
 
-	echo "Adding asdf plugins: $ASDF"
-	$ASDF plugin add erlang || true
-	$ASDF plugin add elixir || true
-	$ASDF install
+	echo "Installing tools with mise: $MISE"
+	$MISE install
 }
 
 function install_mix_deps() {
@@ -128,16 +128,17 @@ function compile_project() {
 # It installs the dependencies, sets up the project, and compiles the project.
 function setup_project() {
 	echo "Installing dependencies (elixir, erlang, etc.)..."
-	# Install dependencies for asdf and Elixir. 
+	# Install dependencies for mise and Elixir. 
 	# Openssl is required for elixir's crypto library.
-	install_asdf_deps
+	install_mise_deps
 	if ! command -v elixir &> /dev/null; then 
-		echo "Elixir is not installed, searching for asdf to install elixir..."
-		if ! command -v asdf &> /dev/null; then 
-			echo "asdf not found, installing dependencies for asdf..."
-			install_asdf
+		echo "Elixir is not installed, searching for mise to install elixir..."
+		export PATH="$HOME/.local/bin:$PATH"
+		if ! command -v mise &> /dev/null; then 
+			echo "mise not found, installing mise..."
+			install_mise
 		else
-			echo "asdf found, installing elixir..."
+			echo "mise found, installing elixir..."
 		fi
 		install_erlang_elixir
 	else


### PR DESCRIPTION
This PR switches `asdf` version manager to [mise](https://mise.jdx.dev/)