### PR TITLE
Use cryptographic randomness for liability split amounts

### DIFF
--- a/lib/liabilities.ex
+++ b/lib/liabilities.ex
@@ -66,9 +66,9 @@ defmodule ProofOfReserves.Liabilities do
     if liability.amount <= @liability_minimum_threshold_sat do
       [liability]
     else
-      # the rand.uniform(n) returns a random number 1 <= x <= n
+      # crypto_rand_uniform(n) returns a random number 1 <= x <= n
       # so the -1 ensures that we never end up with a zero-amount liability.
-      random_split = :rand.uniform(liability.amount - 1)
+      random_split = Util.crypto_rand_uniform(liability.amount - 1)
       a = Liability.new(liability.account_id, liability.account_subkey, random_split)
 
       b =

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -95,6 +95,43 @@ defmodule ProofOfReserves.Util do
   end
 
   @doc """
+  crypto_rand_uniform returns a uniformly-distributed random integer 1 <= x <= n.
+
+  This mirrors :rand.uniform/1 but draws from :crypto.strong_rand_bytes/1.
+  Cryptographic randomness is required here: the amounts chosen when splitting a
+  liability are the only thing masking account balances in the published tree, and
+  every one of them is published verbatim as a leaf value. :rand is seeded per
+  process from the system clock and a pid hash, so its stream is reproducible by
+  anyone who can guess the build time.
+
+  Rejection sampling is used rather than a modulo reduction so that the
+  distribution is exactly uniform. The rejection region is always smaller than
+  half of the sampled range, so this terminates in fewer than 2 draws on average.
+  """
+  @spec crypto_rand_uniform(pos_integer()) :: pos_integer()
+  def crypto_rand_uniform(1), do: 1
+
+  def crypto_rand_uniform(n) when is_integer(n) and n > 1 do
+    byte_len = n |> :binary.encode_unsigned() |> byte_size()
+    bound = 1 <<< (8 * byte_len)
+    # drop the trailing partial interval so every residue is equally likely
+    limit = bound - rem(bound, n)
+
+    draw_below(n, byte_len, limit) + 1
+  end
+
+  @spec draw_below(pos_integer(), pos_integer(), pos_integer()) :: non_neg_integer()
+  defp draw_below(n, byte_len, limit) do
+    byte_len
+    |> :crypto.strong_rand_bytes()
+    |> :binary.decode_unsigned()
+    |> case do
+      v when v < limit -> rem(v, n)
+      _ -> draw_below(n, byte_len, limit)
+    end
+  end
+
+  @doc """
   Replaces all but the first and last 2 bytes of a hash with "...".
   """
   @spec abbr_hash(binary) :: String.t()

--- a/test/liabilities_test.exs
+++ b/test/liabilities_test.exs
@@ -170,4 +170,56 @@ defmodule ProofOfReserves.LiabilitiesTest do
       end)
     end
   end
+
+  describe "split_liability/1" do
+    test "does not split at or below the minimum threshold" do
+      Enum.each([0, 1], fn amount ->
+        liability = Liabilities.fake_liability(amount)
+        assert Liabilities.split_liability(liability) == [liability]
+      end)
+    end
+
+    test "splits 2 sats into two 1-sat liabilities" do
+      assert [a, b] = Liabilities.split_liability(Liabilities.fake_liability(2))
+      assert a.amount == 1
+      assert b.amount == 1
+    end
+
+    test "conserves the amount and never yields a zero-amount liability" do
+      amounts = [2, 3, 10, 12_345, 5_000_000, 2_100_000_000_000_000]
+
+      Enum.each(amounts, fn amount ->
+        Enum.each(1..200, fn _ ->
+          assert [a, b] = Liabilities.split_liability(Liabilities.fake_liability(amount))
+          assert a.amount + b.amount == amount
+          assert a.amount >= 1
+          assert b.amount >= 1
+        end)
+      end)
+    end
+
+    test "preserves account_id and account_subkey" do
+      liability = Liabilities.fake_liability(1_000)
+      assert [a, b] = Liabilities.split_liability(liability)
+
+      Enum.each([a, b], fn split ->
+        assert split.account_id == liability.account_id
+        assert split.account_subkey == liability.account_subkey
+      end)
+    end
+
+    test "split amounts are not reproducible from a :rand seed" do
+      # Regression test: split amounts mask account balances and are published
+      # verbatim as leaf values, so they must not come from a replayable stream.
+      liability = Liabilities.fake_liability(1_000_000_000)
+
+      :rand.seed(:exsss, {42, 42, 42})
+      a = for _ <- 1..20, do: hd(Liabilities.split_liability(liability)).amount
+
+      :rand.seed(:exsss, {42, 42, 42})
+      b = for _ <- 1..20, do: hd(Liabilities.split_liability(liability)).amount
+
+      refute a == b
+    end
+  end
 end

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -38,4 +38,72 @@ defmodule ProofOfReserves.UtilTest do
       assert Util.next_power_of_two(9) == 16
     end
   end
+
+  describe "crypto_rand_uniform/1" do
+    test "n = 1 always returns 1" do
+      Enum.each(1..100, fn _ -> assert Util.crypto_rand_uniform(1) == 1 end)
+    end
+
+    test "stays within 1..n, including at byte boundaries" do
+      ns = [2, 3, 4, 255, 256, 257, 65_535, 65_536, 65_537, 100_000_000, 2_100_000_000_000_000]
+
+      Enum.each(ns, fn n ->
+        Enum.each(1..500, fn _ ->
+          x = Util.crypto_rand_uniform(n)
+          assert x >= 1 and x <= n, "#{x} is outside 1..#{n}"
+        end)
+      end)
+    end
+
+    test "covers the whole range" do
+      draws = for _ <- 1..2_000, do: Util.crypto_rand_uniform(4)
+      assert Enum.sort(Enum.uniq(draws)) == [1, 2, 3, 4]
+    end
+
+    test "rejection sampling removes modulo bias at a byte boundary" do
+      # n = 255 drawn from one byte is the classic biased case: a naive
+      # rem(v, 255) + 1 would make 1 twice as likely as every other value.
+      n = 255
+      trials = n * 400
+      expected = trials / n
+
+      counts =
+        for(_ <- 1..trials, do: Util.crypto_rand_uniform(n))
+        |> Enum.frequencies()
+
+      ones = Map.fetch!(counts, 1)
+
+      assert ones < expected * 1.5,
+             "value 1 appeared #{ones} times, expected ~#{expected} (modulo bias?)"
+    end
+
+    test "is approximately uniform" do
+      n = 4
+      trials = 40_000
+      expected = trials / n
+
+      counts =
+        for(_ <- 1..trials, do: Util.crypto_rand_uniform(n))
+        |> Enum.frequencies()
+
+      Enum.each(1..n, fn v ->
+        count = Map.fetch!(counts, v)
+
+        assert abs(count - expected) < expected * 0.1,
+               "value #{v} appeared #{count} times, expected ~#{expected}"
+      end)
+    end
+
+    test "is not reproducible from a :rand seed" do
+      # Regression test: the draw must not come from :rand, whose stream is
+      # replayable by anyone who can guess the process seed.
+      :rand.seed(:exsss, {1, 2, 3})
+      a = for _ <- 1..20, do: Util.crypto_rand_uniform(1_000_000_000)
+
+      :rand.seed(:exsss, {1, 2, 3})
+      b = for _ <- 1..20, do: Util.crypto_rand_uniform(1_000_000_000)
+
+      refute a == b
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`Liabilities.split_liability/1` drew its split amount from `:rand.uniform/1`.

Split amounts are the only mechanism masking individual account balances in the published liabilities tree — each account's balance is divided into many pieces and shuffled among every other account's pieces, and each piece is published verbatim as a leaf value. That makes the split amounts security-relevant randomness.

`:rand` is not suitable for that. It is seeded per process from the system clock and a pid hash, so its stream is reproducible rather than unpredictable, and the state is recoverable from its outputs. Anyone able to reconstruct that stream can regroup the published leaf values by account.

Note the inconsistency this fixes: `shuffle_liabilities/1` already used `:crypto.strong_rand_bytes` via `Util.crypto_rand_int/0`. Only the split step used `:rand`, which looks like an oversight rather than a decision. The shuffle also does not compensate for it — it randomizes leaf *order*, while the grouping information lives in the *values*.

## Change

Add `Util.crypto_rand_uniform/1`, which mirrors `:rand.uniform/1` semantics (returns `1 <= x <= n`) but draws from `:crypto.strong_rand_bytes/1`, and use it in `split_liability/1`.

It uses rejection sampling rather than a modulo reduction, so the distribution is exactly uniform — a plain `rem(v, n) + 1` biases the low end of the range whenever `n` does not divide the sampled bound. The rejection region is always smaller than half the sampled range, so it terminates in fewer than two draws on average.

No change to the tree format, the hash derivations, or the serialized output. Splitting behaviour is otherwise identical: amounts are still conserved and neither side of a split can be zero.

## Tests

Added 11 tests:

- `crypto_rand_uniform/1`: `n = 1`; range bounds across byte boundaries (255/256/257, 65535/65536/65537, up to 21M BTC in sats); whole-range coverage; absence of modulo bias at `n = 255`, the biased case for a one-byte draw; approximate uniformity over 40k draws.
- `split_liability/1`: no split at or below the 1 sat minimum; 2 sats splits into two 1-sat liabilities; amount conservation and the no-zero-amount invariant across many amounts up to the full 21M BTC supply; `account_id` and `account_subkey` preserved.
- A regression assertion in each module that draws are **not** reproducible from a seeded `:rand` state, so this cannot silently regress.

Full suite: 38 tests, 0 failures (was 27).

Also verified out of band that tree construction is unaffected — amount conservation, power-of-two leaf counts, threshold compliance, and `verify_tree?` all still hold across a range of account counts and thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)